### PR TITLE
Add navigation on rating save

### DIFF
--- a/src/app/rating/rating.component.spec.ts
+++ b/src/app/rating/rating.component.spec.ts
@@ -1,17 +1,38 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Router } from '@angular/router';
+import { Actions } from '@ngrx/effects';
+import { Subject } from 'rxjs';
 import { RatingComponent } from './rating.component';
+import { selectAllGenres } from '../shared/store/genre-rating/genre-rating.selectors';
+import { selectSelectedInstruments } from '../shared/store/instrument/instrument.selectors';
+import { saveGenreRatings, saveGenreRatingsSuccess } from '../shared/store/genre-rating/genre-rating.actions';
 
-describe('VotingComponent', () => {
+describe('RatingComponent', () => {
   let component: RatingComponent;
   let fixture: ComponentFixture<RatingComponent>;
+  let store: MockStore;
+  let actions$: Subject<any>;
+  const mockRouter = { navigate: jasmine.createSpy('navigate') };
 
   beforeEach(async () => {
+    actions$ = new Subject();
     await TestBed.configureTestingModule({
-      declarations: [ RatingComponent ]
-    })
-    .compileComponents();
+      imports: [RatingComponent],
+      providers: [
+        provideMockStore({
+          initialState: {},
+          selectors: [
+            { selector: selectAllGenres, value: [] },
+            { selector: selectSelectedInstruments, value: [] },
+          ],
+        }),
+        { provide: Router, useValue: mockRouter },
+        { provide: Actions, useValue: actions$ },
+      ],
+    }).compileComponents();
 
+    store = TestBed.inject(MockStore);
     fixture = TestBed.createComponent(RatingComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -19,5 +40,17 @@ describe('VotingComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should dispatch saveGenreRatings on submitVotes', () => {
+    spyOn(store, 'dispatch');
+    component.submitVotes();
+    expect(store.dispatch).toHaveBeenCalledWith(saveGenreRatings());
+  });
+
+  it('should navigate to "/instrument" after saveGenreRatingsSuccess', () => {
+    component.submitVotes();
+    actions$.next(saveGenreRatingsSuccess());
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/instrument']);
   });
 });

--- a/src/app/rating/rating.component.ts
+++ b/src/app/rating/rating.component.ts
@@ -1,6 +1,9 @@
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {Observable} from "rxjs";
+import {take} from "rxjs/operators";
 import {Store} from "@ngrx/store";
+import {Actions, ofType} from "@ngrx/effects";
+import {Router} from "@angular/router";
 import {InstrumentState} from "../shared/store/instrument/instrument.reducer";
 import {CommonModule} from "@angular/common";
 import {MatCardModule} from "@angular/material/card";
@@ -11,7 +14,12 @@ import {InstrumentDto} from "../api/models/instrument-dto";
 import {selectSelectedInstruments} from "../shared/store/instrument/instrument.selectors";
 import {GenreRating} from "../shared/store/genre-rating/genre-rating.reducer";
 import {selectAllGenres} from "../shared/store/genre-rating/genre-rating.selectors";
-import {changeRating, saveGenreRatings, setupGenreRatings} from "../shared/store/genre-rating/genre-rating.actions";
+import {
+  changeRating,
+  saveGenreRatings,
+  saveGenreRatingsSuccess,
+  setupGenreRatings
+} from "../shared/store/genre-rating/genre-rating.actions";
 
 @Component({
   selector: 'app-rating',
@@ -24,7 +32,11 @@ export class RatingComponent implements OnInit {
   genreRatings$: Observable<GenreRating[]>;
   selectedInstruments$: Observable<InstrumentDto[]>;
 
-  constructor(private store: Store<InstrumentState>) {
+  constructor(
+    private store: Store<InstrumentState>,
+    private router: Router,
+    private actions$: Actions
+  ) {
     this.genreRatings$ = this.store.select(selectAllGenres);
     this.selectedInstruments$ = this.store.select(selectSelectedInstruments);
   }
@@ -35,6 +47,10 @@ export class RatingComponent implements OnInit {
 
   submitVotes() {
     this.store.dispatch(saveGenreRatings());
+    this.actions$.pipe(
+      ofType(saveGenreRatingsSuccess),
+      take(1)
+    ).subscribe(() => this.router.navigate(['/instrument']));
   }
 
   onRatingChange($event: number, genreRating: GenreRating) {


### PR DESCRIPTION
## Summary
- redirect back to instrument selection after saving votes
- test navigation behavior for RatingComponent

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c1b280dc8326837985c3f025d4e6