### PR TITLE
Enable service worker for API caching

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,7 +35,9 @@
               "src/styles.scss"
             ],
             "scripts": [],
-            "browser": "src/main.ts"
+            "browser": "src/main.ts",
+            "serviceWorker": true,
+            "ngswConfigPath": "ngsw-config.json"
           },
           "configurations": {
             "production": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,8 @@ import {MatMenu, MatMenuItem, MatMenuTrigger} from "@angular/material/menu";
 import {MatSidenav, MatSidenavContainer, MatSidenavContent} from "@angular/material/sidenav";
 import {MatListItem, MatNavList} from "@angular/material/list";
 import {MatIconButton} from "@angular/material/button";
+import {ServiceWorkerModule} from '@angular/service-worker';
+import {environment} from '../environments/environment';
 
 @NgModule({
   declarations: [
@@ -40,7 +42,11 @@ import {MatIconButton} from "@angular/material/button";
     MatListItem,
     MatMenuItem,
     MatSidenav,
-    MatIconButton
+    MatIconButton,
+    ServiceWorkerModule.register('ngsw-worker.js', {
+      enabled: environment.production,
+      registrationStrategy: 'registerWhenStable:30000'
+    })
   ],
   providers: [provideHttpClient(withInterceptorsFromDi())]
 })


### PR DESCRIPTION
## Summary
- register Angular service worker for production
- enable service worker build output

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517414c0148326bb03ee22d030487f